### PR TITLE
Remove shared deps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,8 @@
-(defproject clanhr/ical "0.1.1"
+(defproject clanhr/ical "0.1.2"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-
-  :dependencies.edn "https://raw.githubusercontent.com/clanhr/dependencies/master/dependencies.edn"
-
-  :dependency-sets [:clojure :common]
-  :dependencies []
-
-  :plugins [[clanhr/shared-deps "0.2.6"]])
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [clj-time "0.11.0"]])


### PR DESCRIPTION
Motivation:

Shared deps brings a heavy burden on a project. lein deps :tree takes 60s with
shared deps, and 3s without it. So we'll start using shared deps only on the
services.
